### PR TITLE
Added tqdm to pointcloud requirements

### DIFF
--- a/apps/classification/pointcloud/requirements.txt
+++ b/apps/classification/pointcloud/requirements.txt
@@ -1,3 +1,4 @@
 torch
 h5py
 numpy
+tqdm


### PR DESCRIPTION
I needed to pip install tqdm on my machine as pointcloud/main.py imports tqdm.

Thanks Stephen and Dylan for the repo.