### PR TITLE
Perform division first for numerical stability

### DIFF
--- a/ddn/pytorch/optimal_transport.py
+++ b/ddn/pytorch/optimal_transport.py
@@ -39,8 +39,8 @@ def sinkhorn(M, r=None, c=None, gamma=1.0, eps=1.0e-6, maxiters=1000):
     assert r is None or r.shape == (B, H) or r.shape == (1, H)
     assert c is None or c.shape == (B, W) or c.shape == (1, W)
 
-    if r is None: r = 1.0 / H
-    if c is None: c = 1.0 / W
+    r = 1.0 / H if r is None else r.unsqueeze(dim=2)
+    c = 1.0 / W if c is None else c.unsqueeze(dim=1)
 
     P = torch.exp(-1.0 * gamma * (M - torch.amin(M, 2, keepdim=True)))
     for i in range(maxiters):
@@ -63,8 +63,8 @@ def _sinkhorn_inline(M, r=None, c=None, gamma=1.0, eps=1.0e-6, maxiters=1000):
     assert r is None or r.shape == (B, H) or r.shape == (1, H)
     assert c is None or c.shape == (B, W) or c.shape == (1, W)
 
-    if r is None: r = 1.0 / H
-    if c is None: c = 1.0 / W
+    r = 1.0 / H if r is None else r.unsqueeze(dim=2)
+    c = 1.0 / W if c is None else c.unsqueeze(dim=1)
 
     P = torch.exp(-1.0 * gamma * (M - torch.amin(M, 2, keepdim=True)))
     for i in range(maxiters):

--- a/ddn/pytorch/optimal_transport.py
+++ b/ddn/pytorch/optimal_transport.py
@@ -45,12 +45,13 @@ def sinkhorn(M, r=None, c=None, gamma=1.0, eps=1.0e-6, maxiters=1000):
     P = torch.exp(-1.0 * gamma * (M - torch.amin(M, 2, keepdim=True)))
     for i in range(maxiters):
         alpha = torch.sum(P, 2)
-        P = (r / alpha).view(B, H, 1) * P
+        # Perform division first for numerical stability
+        P = P / alpha.view(B, H, 1) * r
 
         beta = torch.sum(P, 1)
         if torch.max(torch.abs(beta - c)) <= eps:
             break
-        P = P * (c / beta).view(B, 1, W)
+        P = P / beta.view(B, 1, W) * c
 
     return P
 
@@ -68,12 +69,13 @@ def _sinkhorn_inline(M, r=None, c=None, gamma=1.0, eps=1.0e-6, maxiters=1000):
     P = torch.exp(-1.0 * gamma * (M - torch.amin(M, 2, keepdim=True)))
     for i in range(maxiters):
         alpha = torch.sum(P, 2)
-        P *= (r / alpha).view(B, H, 1)
+        # Perform division first for numerical stability
+        P /= alpha.view(B, H, 1); P *= r
 
         beta = torch.sum(P, 1)
         if torch.max(torch.abs(beta - c)) <= eps:
             break
-        P *= (c / beta).view(B, 1, W)
+        P /= beta.view(B, 1, W); P *= c
 
     return P
 


### PR DESCRIPTION
# Optimal Transport Layer

The current implementation of row/column normalisation is unstable when the mass of a given matrix is concentrated on a single row or column. Specifically, `r / alpha` and `c / beta` returns `inf` or `nan` for extremely small row/column sums. The corresponding row/column, however, has the same scale as the row/column sums. Thus, division should be executed first.

## Example
Data: [attn.pt.zip](https://github.com/anucvml/ddn/files/6860069/attn.pt.zip)
Code:
```python
>>> a = torch.load('attn.pt', map_location='cpu')
>>> # M is 1x12x12
>>> M = a[None, 4]
>>> H = W = 12
>>> B = 1
>>> c = r = 1.0 / H
>>> gamma = 1.0
>>> # Exponentiation
>>> P = torch.exp(-1.0 * gamma * (M - torch.amin(M, 2, keepdim=True)))
>>> # Row normalisation
>>> alpha = torch.sum(P, 2)
>>> P = (r / alpha).view(B, H, 1) * P
>>> # Column normalisation
>>> beta = torch.sum(P, 1)

>>> # Current implementation
>>> P_ = P * (c / beta).view(B, 1, W)
>>> print(torch.any(torch.isnan(P_)))
tensor(True)
>>> # Division first
>>> P__ = P / beta.view(B, 1, W) * c
>>> print(torch.any(torch.isnan(P__)))
tensor(False)
```
